### PR TITLE
Update slug column to nullable in posts table

### DIFF
--- a/database/migrations/2022_01_15_171224_update_slug_column_in_posts_table.php
+++ b/database/migrations/2022_01_15_171224_update_slug_column_in_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateSlugColumnInPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('slug')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('slug')->nullable(false)->change();
+        });
+    }
+}


### PR DESCRIPTION
## Context
Update slug column to nullable in posts table migration.

### Value
Allows null value for slug column when a new record is created.

### Changes
- Update `slug` column with `nullable()` method.